### PR TITLE
Only set manifest on shadowJar

### DIFF
--- a/docs/best-practices/ClassLoader-Isolation.md
+++ b/docs/best-practices/ClassLoader-Isolation.md
@@ -14,9 +14,9 @@ GemFire members are started with classloader loader isolation enabled by default
 
 
 ```groovy
-jar {
+shadowJar {
     manifest {
-    attributes 'Multi-Release' : 'true'
+        attributes 'Multi-Release' : 'true'
     }
 }
 ```


### PR DESCRIPTION
We can avoid changing the main jar manifest. Turns out you can use the same attributes on the shadownJar::manfifest.